### PR TITLE
Add redirect for publications page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
-
+gem 'jekyll-redirect-from'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-redirect-from
 
 BUNDLED WITH
    1.16.0

--- a/_config.yml
+++ b/_config.yml
@@ -8,5 +8,5 @@ github_username:  rebeca-lang
 sass:
     style: compressed
 
-
-
+plugins:
+  - jeykyll-redirect-from

--- a/publications.md
+++ b/publications.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Publications
-
+redirect_from: /wiki
 ---
 
 #### 2017


### PR DESCRIPTION
For backward compatibility, we need to redirect url's of old website to corresponding pages in this one.